### PR TITLE
Making PhantomJS2 happy by removing "$"

### DIFF
--- a/lib/instrument.dump.js
+++ b/lib/instrument.dump.js
@@ -23,23 +23,23 @@
         return key;
     }
     function getKey(obj) {
-        if (!hasPrty(obj, "__$__key")) {
-            obj.__$__key = nextKey;
-            if (!hasPrty(obj, '__$__key'))
+        if (!hasPrty(obj, "__jsnapHiddenProp__key")) {
+            obj.__jsnapHiddenProp__key = nextKey;
+            if (!hasPrty(obj, '__jsnapHiddenProp__key'))
                 return lookupImmutableObj(obj); // immutable object; we have to use slow lookup
             nextKey += 1;
         }
-        return obj.__$__key;
+        return obj.__jsnapHiddenProp__key;
     }
     
     var worklist = [];
     var heap = [];
     
     function enqueue(obj) {
-        if (hasPrty(obj, "__$__visited")) {
+        if (hasPrty(obj, "__jsnapHiddenProp__visited")) {
             return;
         }
-        obj.__$__visited = true
+        obj.__jsnapHiddenProp__visited = true
         worklist.push(obj)
     }
     
@@ -51,7 +51,7 @@
         var props = Object.getOwnPropertyNames(obj)
         for (var i=0; i<props.length; i++) {
             var prop = props[i];
-            if (prop.substring(0,5) === '__$__')
+            if (prop.substring(0,5) === '__jsnapHiddenProp__')
                 continue;
             if (prop === '__proto__')
                 continue;
@@ -79,17 +79,17 @@
             }
             objDump.properties.push(descDump)
         }
-        if (!hasPrty(obj, '__$__isEnv')) {
+        if (!hasPrty(obj, '__jsnapHiddenProp__isEnv')) {
             objDump.prototype = convertValue(Object.getPrototypeOf(obj));
         }
-        if (hasPrty(obj, '__$__env')) {
-            if (obj.__$__env !== window) {
-                obj.__$__env.__$__isEnv = true;
+        if (hasPrty(obj, '__jsnapHiddenProp__env')) {
+            if (obj.__jsnapHiddenProp__env !== window) {
+                obj.__jsnapHiddenProp__env.__jsnapHiddenProp__isEnv = true;
             }
-            objDump.env = convertValue(obj.__$__env);
+            objDump.env = convertValue(obj.__jsnapHiddenProp__env);
         }
-        if (hasPrty(obj, '__$__fun') && typeof obj.__$__fun !== 'undefined') {
-            objDump.function = convertFun(obj.__$__fun);
+        if (hasPrty(obj, '__jsnapHiddenProp__fun') && typeof obj.__jsnapHiddenProp__fun !== 'undefined') {
+            objDump.function = convertFun(obj.__jsnapHiddenProp__fun);
         } else if (typeof obj === 'function') {
             objDump.function = {type:'unknown'}
         }
@@ -138,7 +138,7 @@
         heap: heap
     }
     
-    __$__print(JSON.stringify(output));
+    __jsnapHiddenProp__print(JSON.stringify(output));
     
     // if (process && process.exit) {
     //     process.exit();

--- a/lib/instrument.dump.js
+++ b/lib/instrument.dump.js
@@ -51,7 +51,7 @@
         var props = Object.getOwnPropertyNames(obj)
         for (var i=0; i<props.length; i++) {
             var prop = props[i];
-            if (prop.substring(0,5) === '__jsnapHiddenProp__')
+            if (prop.substring(0,19) === '__jsnapHiddenProp__')
                 continue;
             if (prop === '__proto__')
                 continue;

--- a/lib/instrument.js
+++ b/lib/instrument.js
@@ -171,7 +171,7 @@ function resolveId(node,name) {
 function wrapID(x) {
     return {
         type: 'CallExpression',
-        callee: {type:'Identifier', name:'__$__id'},
+        callee: {type:'Identifier', name:'__jsnapHiddenProp__id'},
         arguments: [x]
     }
 }
@@ -252,7 +252,7 @@ function transform(node) {
                         operator:'=',
                         left: {
                             type: 'MemberExpression',
-                            object: ident("__$__env" + fun.$depth),
+                            object: ident("__jsnapHiddenProp__env" + fun.$depth),
                             property: ident(decl.id.name)
                         },
                         right: decl.init
@@ -264,7 +264,7 @@ function transform(node) {
                 } else if (node.$parent.type === 'ForInStatement' && node.$parent.left === node) {
                     replacement = { 
                         type: 'MemberExpression',
-                        object: ident("__$__env" + fun.$depth),
+                        object: ident("__jsnapHiddenProp__env" + fun.$depth),
                         property: ident(node.declarations[0].id.name)
                     }
                 } else {
@@ -283,7 +283,7 @@ function transform(node) {
                 if (depth > 0) {
                     replacement = {
                         type:'MemberExpression',
-                        object: ident('__$__env' + depth),
+                        object: ident('__jsnapHiddenProp__env' + depth),
                         property: ident(node.name)
                     }
                     if (node.$parent.type === 'CallExpression' && node.$parent.callee === node) {
@@ -322,10 +322,10 @@ function transform(node) {
                     callee: {
                         type: 'MemberExpression',
                         object: node,
-                        property: ident("__$__initObject")
+                        property: ident("__jsnapHiddenProp__initObject")
                     },
                     arguments: [
-                        ident("__$__env" + scope.$depth),
+                        ident("__jsnapHiddenProp__env" + scope.$depth),
                         {
                             type: 'ArrayExpression',
                             elements: ids.map(function(x) {
@@ -345,14 +345,14 @@ function transform(node) {
                 kind:'var',
                 declarations:[{
                     type:'VariableDeclarator',
-                    id: {type:'Identifier', name:'__$__env' + node.$depth},
+                    id: {type:'Identifier', name:'__jsnapHiddenProp__env' + node.$depth},
                     init: {
                         type:'ObjectExpression',
                         properties:[{
                             type:'Property',
                             kind:'init',
-                            key:ident("__$__env"),
-                            value:ident("__$__env" + (node.$depth-1))
+                            key:ident("__jsnapHiddenProp__env"),
+                            value:ident("__jsnapHiddenProp__env" + (node.$depth-1))
                         }].concat(node.params.map(function(param) {
                             return {
                                 type:'Property',
@@ -373,10 +373,10 @@ function transform(node) {
                     callee: {
                         type:'MemberExpression',
                         object:node,
-                        property:{type:'Identifier', name:"__$__initFunction"}
+                        property:{type:'Identifier', name:"__jsnapHiddenProp__initFunction"}
                     },
                     arguments: [
-                        {type:'Identifier', name:"__$__env" + (node.$depth - 1)}, 
+                        {type:'Identifier', name:"__jsnapHiddenProp__env" + (node.$depth - 1)}, 
                         {type:'Literal', value:node.$functionId}
                     ]
                 }
@@ -386,10 +386,10 @@ function transform(node) {
                     callee: {
                         type:'MemberExpression',
                         object: ident(node.id.name),
-                        property: ident("__$__initFunction")
+                        property: ident("__jsnapHiddenProp__initFunction")
                     },
                     arguments: [
-                        ident("__$__env" + (node.$depth-1)),
+                        ident("__jsnapHiddenProp__env" + (node.$depth-1)),
                         {type:'Literal', value:node.$functionId}
                     ]
                 }))
@@ -398,7 +398,7 @@ function transform(node) {
                     operator:'=',
                     left: {
                         type: 'MemberExpression',
-                        object: ident("__$__env" + (node.$depth-1)),
+                        object: ident("__jsnapHiddenProp__env" + (node.$depth-1)),
                         property: ident(node.id.name)
                     },
                     right: ident(node.id.name)
@@ -412,14 +412,14 @@ function transform(node) {
                 kind: 'var',
                 declarations: [{
                     type: 'VariableDeclarator',
-                    id: ident("__$__env" + node.$depth),
+                    id: ident("__jsnapHiddenProp__env" + node.$depth),
                     init: {
                         type: 'ObjectExpression',
                         properties: [{
                             type: 'Property',
                             kind: 'init',
-                            key: ident("__$__env"),
-                            value: ident("__$__env" + (node.$depth - 1))
+                            key: ident("__jsnapHiddenProp__env"),
+                            value: ident("__jsnapHiddenProp__env" + (node.$depth - 1))
                         },{
                             type: 'Property',
                             kind: 'init',
@@ -468,7 +468,7 @@ function makeNativeInitializer(name) {
     return wrapStmt({
         type: 'Assignment',
         operator: '=',
-        left: { type: 'MemberExpression', object:exp, property:ident('__$__functionId') }
+        left: { type: 'MemberExpression', object:exp, property:ident('__jsnapHiddenProp__functionId') }
     })
 }
 

--- a/lib/instrument.prelude.js
+++ b/lib/instrument.prelude.js
@@ -62,7 +62,7 @@
     Object.getOwnPropertyNames = function(o) {
         var array = getOwnPropertyNames.call(_Object,o);
         return array.filter(function (x) {
-            return x.substring(0,5) !== "__jsnapHiddenProp__";
+            return x.substring(0,19) !== "__jsnapHiddenProp__";
         });
     }
     

--- a/lib/instrument.prelude.js
+++ b/lib/instrument.prelude.js
@@ -41,7 +41,7 @@
     }
     
     var _log = console.log
-    defineHiddenProperty(window, "__$__print", function(x) {
+    defineHiddenProperty(window, "__jsnapHiddenProp__print", function(x) {
         _log.call(console, x)
     })
     
@@ -53,26 +53,26 @@
         // Only redefine Function.prototype.bind if already existed
         Function.prototype.bind = function() {
             var f = _bind.apply(this, arguments);
-            defineHiddenProperty(f, "__$__fun", {type:'bind', target:this, arguments:toArray(arguments)})
+            defineHiddenProperty(f, "__jsnapHiddenProp__fun", {type:'bind', target:this, arguments:toArray(arguments)})
             return f;
         }
     }
     
-    // hide the injected properties (anything starting with __$__)
+    // hide the injected properties (anything starting with __jsnapHiddenProp__)
     Object.getOwnPropertyNames = function(o) {
         var array = getOwnPropertyNames.call(_Object,o);
         return array.filter(function (x) {
-            return x.substring(0,5) !== "__$__";
+            return x.substring(0,5) !== "__jsnapHiddenProp__";
         });
     }
     
-    defineHiddenProperty(Function.prototype, "__$__initFunction", function(env,id) {
-        defineHiddenProperty(this, "__$__env", env);
-        defineHiddenProperty(this, "__$__fun", {type:'user', id:id});
+    defineHiddenProperty(Function.prototype, "__jsnapHiddenProp__initFunction", function(env,id) {
+        defineHiddenProperty(this, "__jsnapHiddenProp__env", env);
+        defineHiddenProperty(this, "__jsnapHiddenProp__fun", {type:'user', id:id});
         return this;
     });
         
-    defineHiddenProperty(Object.prototype, "__$__initObject", function(env,ids) {
+    defineHiddenProperty(Object.prototype, "__jsnapHiddenProp__initObject", function(env,ids) {
         var obj = this;
         var names = getOwnPropertyNames.call(_Object, obj);
         var idIdx = 0;
@@ -80,22 +80,22 @@
             var name = names[k];
             var desc = getOwnPropertyDescriptor.call(_Object, obj, name); //getOwnPropertyDescriptor.call(obj, name);
             if (desc.get) {
-                defineHiddenProperty(desc.get, "__$__env", env)
-                defineHiddenProperty(desc.get, "__$__fun", {type:'user', id:ids[idIdx++]})
+                defineHiddenProperty(desc.get, "__jsnapHiddenProp__env", env)
+                defineHiddenProperty(desc.get, "__jsnapHiddenProp__fun", {type:'user', id:ids[idIdx++]})
             }
             if (desc.set) {
-                defineHiddenProperty(desc.set, "__$__env", env)
-                defineHiddenProperty(desc.set, "__$__fun", {type:'user', id:ids[idIdx++]})
+                defineHiddenProperty(desc.set, "__jsnapHiddenProp__env", env)
+                defineHiddenProperty(desc.set, "__jsnapHiddenProp__fun", {type:'user', id:ids[idIdx++]})
             }
         }
         return this;
     });
         
-    defineHiddenProperty(window, "__$__id", function(x) {
+    defineHiddenProperty(window, "__jsnapHiddenProp__id", function(x) {
         return x;
     });
         
-    defineHiddenProperty(window, "__$__env0", window);
+    defineHiddenProperty(window, "__jsnapHiddenProp__env0", window);
     
     function instrumentNatives(names) {
         names.forEach(function(name) {
@@ -124,11 +124,11 @@
                 // _log.call(console, "Invalid native: " + name)
                 return;
             }
-            if (obj.hasOwnProperty("__$__fun")) {
-                // _log.call(console, "Duplicate native: " + name + " vs " + obj.__$__fun.id)
+            if (obj.hasOwnProperty("__jsnapHiddenProp__fun")) {
+                // _log.call(console, "Duplicate native: " + name + " vs " + obj.__jsnapHiddenProp__fun.id)
                 return;
             }
-            defineHiddenProperty(obj, "__$__fun", {type:'native', id:name})
+            defineHiddenProperty(obj, "__jsnapHiddenProp__fun", {type:'native', id:name})
         })
     }
     

--- a/lib/nativedump.js
+++ b/lib/nativedump.js
@@ -47,7 +47,7 @@
         var names = Object.getOwnPropertyNames(x)
         for (var i=0; i<names.length; i++) {
             var name = names[i];
-            if (name.substring(0,5) === '__jsnapHiddenProp__')
+            if (name.substring(0,19) === '__jsnapHiddenProp__')
                 continue; // skip injected properties
             if (typeof x === 'function' && (name === 'arguments' || name === 'caller'))
                 continue; // skip the call stack properties

--- a/lib/nativedump.js
+++ b/lib/nativedump.js
@@ -31,23 +31,23 @@
             return;
         if (x === null)
             return;
-        if (x.hasOwnProperty("__$__queued")) {
+        if (x.hasOwnProperty("__jsnapHiddenProp__queued")) {
             return;
         }
-        x.__$__queued = true;
-        x.__$__path = path;
+        x.__jsnapHiddenProp__queued = true;
+        x.__jsnapHiddenProp__path = path;
         queue.push(x)
     }
     
     function visit(x) {
-        var path = x.__$__path;
+        var path = x.__jsnapHiddenProp__path;
         if (typeof x === 'function') {
             paths['$' + path] = true
         }
         var names = Object.getOwnPropertyNames(x)
         for (var i=0; i<names.length; i++) {
             var name = names[i];
-            if (name.substring(0,5) === '__$__')
+            if (name.substring(0,5) === '__jsnapHiddenProp__')
                 continue; // skip injected properties
             if (typeof x === 'function' && (name === 'arguments' || name === 'caller'))
                 continue; // skip the call stack properties
@@ -76,7 +76,7 @@
     }
     
     function blacklist(x) {
-        x.__$__queued = true;
+        x.__jsnapHiddenProp__queued = true;
     }
     
     var isPhantomJs = !!window._phantom;
@@ -101,7 +101,7 @@
             break;
         }
         var x = protoQueue.pop();
-        enqueue(Object.getPrototypeOf(x), x.__$__path + '.__proto__')
+        enqueue(Object.getPrototypeOf(x), x.__jsnapHiddenProp__path + '.__proto__')
     }
     
     for (var k in paths) {


### PR DESCRIPTION
If a script has a "$" in a property name when running PhantomJS2, something like the following happens: 

```
InvalidCharacterError: DOM Exception 5: An invalid or illegal character was specified, such as in an XML name.

  C:\Users\webbies\AppData\Local\Temp\jsnap11598-1660-1btzzpk:20585 in enqueue
  C:\Users\webbies\AppData\Local\Temp\jsnap11598-1660-1btzzpk:20653 in convertValue
  C:\Users\webbies\AppData\Local\Temp\jsnap11598-1660-1btzzpk:20621 in dump
  C:\Users\webbies\AppData\Local\Temp\jsnap11598-1660-1btzzpk:20676
```

But if you change all the "**$**" to something else that doesn't include "$", then PhantomJS2 is happy. 
So that is what is done in this pull-request.

I don't think this project should update the package.json to include phantomjs2 instead of the current phantomjs, because the installation of phantomjs2 doesn't work well on all platforms when using npm. 
